### PR TITLE
Integrate Supabase for authentication and metadata

### DIFF
--- a/frontend/mobile/package.json
+++ b/frontend/mobile/package.json
@@ -36,6 +36,7 @@
     "@capacitor/share": "6.0.0",
     "@capacitor/status-bar": "6.0.0",
     "@ionic/angular": "^8.0.0",
+    "@supabase/supabase-js": "^2.39.5",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/frontend/mobile/src/app/models/types.ts
+++ b/frontend/mobile/src/app/models/types.ts
@@ -1,5 +1,5 @@
 export interface User {
-  id: number;
+  id: string;
   email: string;
   createdAt: string;
 }

--- a/frontend/mobile/src/app/services/albums.service.ts
+++ b/frontend/mobile/src/app/services/albums.service.ts
@@ -1,21 +1,89 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, from } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 import { Album, AlbumDetail, CreateAlbumRequest, SelectionSummary, FinalizeAlbumRequest } from '../models/types';
+import { SupabaseService } from './supabase.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AlbumsService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private supabase: SupabaseService) {}
 
   createAlbum(projectId: number, request: CreateAlbumRequest): Observable<Album> {
-    return this.http.post<Album>(`${environment.apiUrl}/projects/${projectId}/albums`, request);
+    const slug = Math.random().toString(36).substring(2, 10);
+    return from(
+      this.supabase.client
+        .from('albums')
+        .insert({
+          project_id: projectId,
+          title: request.title,
+          selection_limit: request.selectionLimit ?? 0,
+          slug
+        })
+        .select('*')
+        .single()
+    ).pipe(
+      map(({ data, error }) => {
+        if (error) throw error;
+        return {
+          id: data.id,
+          projectId: data.project_id,
+          slug: data.slug,
+          title: data.title,
+          version: data.version,
+          allowSelection: data.allow_selection,
+          selectionLimit: data.selection_limit,
+          status: data.status,
+          createdAt: data.created_at,
+          shareUrl: `${environment.viewerBaseUrl}/a/${data.slug}`,
+          qrPngBase64: ''
+        } as Album;
+      })
+    );
   }
 
   getAlbumDetail(albumId: number): Observable<AlbumDetail> {
-    return this.http.get<AlbumDetail>(`${environment.apiUrl}/albums/${albumId}`);
+    return from(
+      this.supabase.client
+        .from('albums')
+        .select('*, album_items(*)')
+        .eq('id', albumId)
+        .single()
+    ).pipe(
+      map(({ data, error }) => {
+        if (error) throw error;
+        const album = data as any;
+        return {
+          id: album.id,
+          projectId: album.project_id,
+          slug: album.slug,
+          title: album.title,
+          version: album.version,
+          allowSelection: album.allow_selection,
+          selectionLimit: album.selection_limit,
+          status: album.status,
+          createdAt: album.created_at,
+          items: (album.album_items || []).map((i: any) => ({
+            id: i.id,
+            projectId: i.project_id,
+            albumId: i.album_id,
+            serialNo: i.serial_no,
+            kind: i.kind,
+            srcUrl: i.src_url,
+            wmUrl: i.wm_url || undefined,
+            thumbUrl: i.thumb_url || undefined,
+            width: i.width || undefined,
+            height: i.height || undefined,
+            bytes: i.bytes || undefined,
+            sortOrder: i.sort_order,
+            createdAt: i.created_at
+          }))
+        } as AlbumDetail;
+      })
+    );
   }
 
   getSelectionSummary(albumId: number): Observable<SelectionSummary[]> {

--- a/frontend/mobile/src/app/services/projects.service.ts
+++ b/frontend/mobile/src/app/services/projects.service.ts
@@ -1,24 +1,78 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
-import { environment } from '../../environments/environment';
-import { Project, ProjectDetail, CreateProjectRequest } from '../models/types';
+import { Observable, from } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Project, ProjectDetail, CreateProjectRequest, AlbumSummary } from '../models/types';
+import { SupabaseService } from './supabase.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ProjectsService {
-  constructor(private http: HttpClient) {}
+  constructor(private supabase: SupabaseService) {}
 
   createProject(request: CreateProjectRequest): Observable<Project> {
-    return this.http.post<Project>(`${environment.apiUrl}/projects`, request);
+    return from(
+      this.supabase.client
+        .from('projects')
+        .insert({ name: request.name })
+        .select('*')
+        .single()
+    ).pipe(
+      map(({ data, error }) => {
+        if (error) throw error;
+        return {
+          id: data.id,
+          name: data.name,
+          key: data.key,
+          createdAt: data.created_at,
+          albumCount: 0
+        } as Project;
+      })
+    );
   }
 
   getProjects(): Observable<Project[]> {
-    return this.http.get<Project[]>(`${environment.apiUrl}/projects`);
+    return from(this.supabase.client.from('projects').select('*')).pipe(
+      map(({ data, error }) => {
+        if (error) throw error;
+        return (data as any[]).map((p: any) => ({
+          id: p.id,
+          name: p.name,
+          key: p.key,
+          createdAt: p.created_at,
+          albumCount: 0
+        })) as Project[];
+      })
+    );
   }
 
   getProjectDetail(id: number): Observable<ProjectDetail> {
-    return this.http.get<ProjectDetail>(`${environment.apiUrl}/projects/${id}`);
+    return from(
+      this.supabase.client
+        .from('projects')
+        .select('*, albums(*)')
+        .eq('id', id)
+        .single()
+    ).pipe(
+      map(({ data, error }) => {
+        if (error) throw error;
+        const project = data as any;
+        return {
+          id: project.id,
+          name: project.name,
+          key: project.key,
+          createdAt: project.created_at,
+          albums: (project.albums || []).map((a: any) => ({
+            id: a.id,
+            slug: a.slug,
+            title: a.title,
+            version: a.version,
+            status: a.status,
+            itemCount: 0,
+            createdAt: a.created_at
+          })) as AlbumSummary[]
+        } as ProjectDetail;
+      })
+    );
   }
 }

--- a/frontend/mobile/src/app/services/supabase.service.ts
+++ b/frontend/mobile/src/app/services/supabase.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { environment } from '../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SupabaseService {
+  private _client: SupabaseClient;
+
+  constructor() {
+    this._client = createClient(environment.supabaseUrl, environment.supabaseAnonKey);
+  }
+
+  get client(): SupabaseClient {
+    return this._client;
+  }
+}

--- a/frontend/mobile/src/environments/environment.prod.ts
+++ b/frontend/mobile/src/environments/environment.prod.ts
@@ -1,5 +1,7 @@
 export const environment = {
   production: true,
   apiUrl: 'https://api.qralbums.app',
-  viewerBaseUrl: 'https://viewer.qralbums.app'
+  viewerBaseUrl: 'https://viewer.qralbums.app',
+  supabaseUrl: 'https://your-supabase-url.supabase.co',
+  supabaseAnonKey: 'public-anon-key'
 };

--- a/frontend/mobile/src/environments/environment.ts
+++ b/frontend/mobile/src/environments/environment.ts
@@ -1,5 +1,7 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:5000',
-  viewerBaseUrl: 'https://viewer.qralbums.app'
+  viewerBaseUrl: 'https://viewer.qralbums.app',
+  supabaseUrl: 'https://your-supabase-url.supabase.co',
+  supabaseAnonKey: 'public-anon-key'
 };


### PR DESCRIPTION
## Summary
- add Supabase client service
- switch auth, project, and album services to Supabase
- expose Supabase URL and key in environments

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fsupabase-js)*
- `npm test` *(fails: ENOENT tsconfig.spec.json)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c45a974d40832fb4ca77acca56af7d