### PR TITLE
feat: migrate backend to supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A comprehensive QR-based album management system with mobile app and API backend
 ## Architecture
 
 - **Mobile App**: Ionic + Angular with Capacitor (Android/iOS)
-- **API**: .NET 8 Minimal API with EF Core and MySQL
+- **API**: .NET 8 Minimal API with EF Core and Supabase (PostgreSQL)
 - **Media**: Bunny Storage + CDN + Stream integration
 - **Auth**: JWT-based authentication
 - **QR**: Dynamic QR code generation for album sharing
@@ -16,7 +16,7 @@ A comprehensive QR-based album management system with mobile app and API backend
 
 - Node.js 18+ LTS
 - .NET 8 SDK
-- MySQL 8.0+
+- Supabase PostgreSQL database
 - Android Studio (for Android builds)
 - Xcode (for iOS builds, macOS only)
 
@@ -36,7 +36,7 @@ npm install
 
 3. **Configure API environment** (`backend/api/.env`):
 ```bash
-ConnectionStrings__Default="Server=localhost;Database=qralbums;Uid=root;Pwd=yourpassword;"
+ConnectionStrings__Default="Host=your_supabase_host;Port=5432;Database=postgres;Username=postgres;Password=yourpassword;SslMode=Require;Trust Server Certificate=true"
 Jwt__Secret="your-super-secret-jwt-key-min-32-chars"
 Bunny__StorageZone="your-storage-zone"
 Bunny__AccessKey="your-bunny-access-key"

--- a/backend/api/Data/QRAlbumsContextFactory.cs
+++ b/backend/api/Data/QRAlbumsContextFactory.cs
@@ -24,7 +24,7 @@ public sealed class QRAlbumsContextFactory : IDesignTimeDbContextFactory<QRAlbum
                  ?? throw new InvalidOperationException("ConnectionStrings:Default missing");
 
         var builder = new DbContextOptionsBuilder<QRAlbumsContext>();
-        builder.UseMySql(cs, ServerVersion.AutoDetect(cs));
+        builder.UseNpgsql(cs);
         return new QRAlbumsContext(builder.Options);
     }
 }

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -24,7 +24,7 @@ builder.Services.AddDbContext<QRAlbumsContext>(opts =>
              Environment.GetEnvironmentVariable("ConnectionStrings__Default");
     if (string.IsNullOrWhiteSpace(cs))
         throw new InvalidOperationException("DB connection string not configured");
-    opts.UseMySql(cs, ServerVersion.AutoDetect(cs));
+    opts.UseNpgsql(cs);
 });
 
 // JWT Authentication

--- a/backend/api/QRAlbums.API.csproj
+++ b/backend/api/QRAlbums.API.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />

--- a/backend/api/appsettings.Development.json
+++ b/backend/api/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Default": "Server=localhost;Database=qralbums;User=app;Password=change_me;SslMode=None;"
+    "Default": "Host=your_supabase_host;Port=5432;Database=postgres;Username=postgres;Password=change_me;SslMode=Require;Trust Server Certificate=true"
   },
   "Bunny": {
     "StorageZone": "<your-storage-zone>",

--- a/backend/api/appsettings.json
+++ b/backend/api/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Default": "Server=localhost;Database=qralbums;User=app;Password=change_me;SslMode=None;"
+    "Default": "Host=your_supabase_host;Port=5432;Database=postgres;Username=postgres;Password=change_me;SslMode=Require;Trust Server Certificate=true"
   },
   "Bunny": {
     "StorageZone": "<your-storage-zone>",


### PR DESCRIPTION
## Summary
- switch EF Core to Npgsql for Supabase PostgreSQL
- update connection strings and docs for Supabase

## Testing
- `dotnet test backend/api.tests/QRAlbums.API.Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c45d8ae750832fbc2e481dd7fca012