### PR TITLE
Ensure auth persists across refresh and fix project counter

### DIFF
--- a/backend/api/Services/ProjectService.cs
+++ b/backend/api/Services/ProjectService.cs
@@ -23,10 +23,10 @@ public class ProjectService : IProjectService
         };
 
         _context.Projects.Add(project);
-        
-        // Initialize counter
+        await _context.SaveChangesAsync();
+
+        // Initialize counter after project ID is generated
         _context.ProjectCounters.Add(new ProjectCounter { ProjectId = project.Id });
-        
         await _context.SaveChangesAsync();
 
         return new ProjectDto(project.Id, project.Name, project.Key, project.CreatedAt, 0);

--- a/frontend/mobile/src/app/services/auth.service.ts
+++ b/frontend/mobile/src/app/services/auth.service.ts
@@ -16,11 +16,9 @@ export class AuthService {
   public currentUser$ = this.currentUserSubject.asObservable();
   public token$ = this.tokenSubject.asObservable();
 
-  constructor(private http: HttpClient) {
-    this.loadStoredAuth();
-  }
+  constructor(private http: HttpClient) {}
 
-  private async loadStoredAuth() {
+  async init() {
     try {
       const { value: token } = await Preferences.get({ key: 'auth_token' });
       const { value: userJson } = await Preferences.get({ key: 'current_user' });

--- a/frontend/mobile/src/main.ts
+++ b/frontend/mobile/src/main.ts
@@ -1,4 +1,5 @@
 import { bootstrapApplication } from '@angular/platform-browser';
+import { APP_INITIALIZER } from '@angular/core';
 import { RouteReuseStrategy, provideRouter } from '@angular/router';
 import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
 
@@ -6,12 +7,18 @@ import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { authInterceptor } from './app/interceptors/auth.interceptor';
+import { AuthService } from './app/services/auth.service';
+
+export function initAuth(authService: AuthService) {
+  return () => authService.init();
+}
 
 bootstrapApplication(AppComponent, {
   providers: [
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular(),
     provideRouter(routes),
-    provideHttpClient(withInterceptors([authInterceptor]))
+    provideHttpClient(withInterceptors([authInterceptor])),
+    { provide: APP_INITIALIZER, useFactory: initAuth, deps: [AuthService], multi: true }
   ],
 });


### PR DESCRIPTION
## Summary
- wait for stored auth token on app bootstrap to prevent logout on refresh
- save new project before initializing its counter to avoid unknown key errors

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ENOENT tsconfig.spec.json)*
- `npm run lint` *(fails: No ESLint configuration found)*
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5480c9b9c832f8c04fdfe8d87836c