### PR TITLE
feat: support album updates

### DIFF
--- a/backend/api/Controllers/AlbumController.cs
+++ b/backend/api/Controllers/AlbumController.cs
@@ -27,6 +27,14 @@ public static class AlbumController
             return album != null ? Results.Ok(album) : Results.NotFound();
         });
 
+        // Update album
+        group.MapPut("/albums/{id:long}", async (long id, UpdateAlbumRequest request, IAlbumService albumService, HttpContext context) =>
+        {
+            var userId = GetUserId(context);
+            var album = await albumService.UpdateAlbumAsync(userId, id, request);
+            return album != null ? Results.Ok(album) : Results.NotFound();
+        });
+
         // Get selection summary
         group.MapGet("/albums/{id:long}/selections/summary", async (long id, IAlbumService albumService, HttpContext context) =>
         {

--- a/backend/api/Controllers/MediaController.cs
+++ b/backend/api/Controllers/MediaController.cs
@@ -28,6 +28,12 @@ public static class MediaController
             return Results.Created($"/albums/{albumId}/items/{result.ItemId}", result);
         }).DisableAntiforgery();
 
+        albumGroup.MapDelete("{albumId:long}/items/{itemId:long}", async (long albumId, long itemId, IMediaService mediaService) =>
+        {
+            var success = await mediaService.DeleteItemAsync(albumId, itemId);
+            return success ? Results.NoContent() : Results.NotFound();
+        });
+
         var mediaGroup = app.MapGroup("/media").WithTags("Media").RequireAuthorization();
 
         mediaGroup.MapGet("cdn", (string path, IBunnyService bunnyService) =>

--- a/backend/api/Models/DTOs.cs
+++ b/backend/api/Models/DTOs.cs
@@ -17,6 +17,7 @@ public record ProjectDetailDto(long Id, string Name, string Key, DateTime Create
 
 // Album DTOs
 public record CreateAlbumRequest(string Title, int SelectionLimit = 0);
+public record UpdateAlbumRequest(string Title);
 public record AlbumDto(long Id, long ProjectId, string Slug, string Title, AlbumVersion Version, bool AllowSelection, int SelectionLimit, AlbumStatus Status, DateTime CreatedAt, string ShareUrl, string QrPngBase64);
 public record AlbumSummaryDto(long Id, string Slug, string Title, AlbumVersion Version, AlbumStatus Status, int ItemCount, DateTime CreatedAt);
 public record AlbumDetailDto(long Id, long ProjectId, string Slug, string Title, AlbumVersion Version, bool AllowSelection, int SelectionLimit, AlbumStatus Status, DateTime CreatedAt, List<AlbumItemDto> Items);

--- a/backend/api/Services/AlbumService.cs
+++ b/backend/api/Services/AlbumService.cs
@@ -61,6 +61,20 @@ public class AlbumService : IAlbumService
         return new AlbumDetailDto(album.Id, album.ProjectId, album.Slug, album.Title, album.Version, album.AllowSelection, album.SelectionLimit, album.Status, album.CreatedAt, items);
     }
 
+    public async Task<AlbumDto?> UpdateAlbumAsync(long userId, long albumId, UpdateAlbumRequest request)
+    {
+        var album = await _context.Albums.FirstOrDefaultAsync(a => a.Id == albumId && a.OwnerId == userId);
+        if (album == null) return null;
+
+        album.Title = request.Title;
+        await _context.SaveChangesAsync();
+
+        var shareUrl = $"{_config["Frontend:ViewerBaseUrl"]}/a/{album.Slug}";
+        var qrPngBase64 = _qrService.GenerateQRCodeBase64(shareUrl);
+
+        return new AlbumDto(album.Id, album.ProjectId, album.Slug, album.Title, album.Version, album.AllowSelection, album.SelectionLimit, album.Status, album.CreatedAt, shareUrl, qrPngBase64);
+    }
+
     public async Task<List<SelectionSummaryDto>> GetSelectionSummaryAsync(long userId, long albumId)
     {
         // Verify ownership

--- a/backend/api/Services/IServices.cs
+++ b/backend/api/Services/IServices.cs
@@ -23,6 +23,7 @@ public interface IAlbumService
 {
     Task<AlbumDto> CreateAlbumAsync(long userId, long projectId, CreateAlbumRequest request);
     Task<AlbumDetailDto?> GetAlbumDetailAsync(long userId, long albumId);
+    Task<AlbumDto?> UpdateAlbumAsync(long userId, long albumId, UpdateAlbumRequest request);
     Task<List<SelectionSummaryDto>> GetSelectionSummaryAsync(long userId, long albumId);
     Task<AlbumDto> FinalizeAlbumAsync(long userId, long albumId, FinalizeAlbumRequest request);
 }
@@ -30,6 +31,7 @@ public interface IAlbumService
 public interface IMediaService
 {
     Task<UploadResponse> UploadItemAsync(long albumId, IFormFile file, ItemKind kind, bool watermarkEnabled = false, string? watermarkText = null);
+    Task<bool> DeleteItemAsync(long albumId, long itemId);
 }
 
 public interface ISelectionService

--- a/backend/api/Services/MediaService.cs
+++ b/backend/api/Services/MediaService.cs
@@ -82,4 +82,15 @@ public class MediaService : IMediaService
 
         return new UploadResponse(item.Id, item.ProjectId, item.AlbumId, item.SerialNo, srcUrl, wmUrl, thumbUrl);
     }
+
+    public async Task<bool> DeleteItemAsync(long albumId, long itemId)
+    {
+        var item = await _context.AlbumItems.FirstOrDefaultAsync(i => i.Id == itemId && i.AlbumId == albumId);
+        if (item == null) return false;
+
+        _context.AlbumItems.Remove(item);
+        await _context.SaveChangesAsync();
+
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary
- allow renaming albums
- support removing uploaded items

## Testing
- `dotnet test backend/api.tests/QRAlbums.API.Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c568a6706c832f870bf5f4421468ab