### PR TITLE
Add dashboard with theme toggle and album upload improvements

### DIFF
--- a/frontend/mobile/src/app/app.routes.ts
+++ b/frontend/mobile/src/app/app.routes.ts
@@ -4,7 +4,7 @@ import { authGuard } from './guards/auth.guard';
 export const routes: Routes = [
   {
     path: '',
-    redirectTo: '/projects',
+    redirectTo: '/dashboard',
     pathMatch: 'full',
   },
   {
@@ -12,12 +12,17 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/auth/auth.page').then(m => m.AuthPage)
   },
   {
-    path: 'projects',
+    path: 'dashboard',
+    canActivate: [authGuard],
+    loadComponent: () => import('./pages/dashboard/dashboard.page').then(m => m.DashboardPage)
+  },
+  {
+    path: 'project',
     canActivate: [authGuard],
     loadComponent: () => import('./pages/projects/projects.page').then(m => m.ProjectsPage)
   },
   {
-    path: 'projects/:id',
+    path: 'project/:id',
     canActivate: [authGuard],
     loadComponent: () => import('./pages/project-detail/project-detail.page').then(m => m.ProjectDetailPage)
   },

--- a/frontend/mobile/src/app/pages/album-detail/album-detail.page.html
+++ b/frontend/mobile/src/app/pages/album-detail/album-detail.page.html
@@ -37,7 +37,7 @@
           {{ album.version }}
         </ion-badge>
       </div>
-      
+
       <div class="album-meta">
         <p>{{ album.items.length }} items</p>
         <p *ngIf="album.version === AlbumVersion.RAW && album.selectionLimit > 0">
@@ -45,6 +45,7 @@
         </p>
         <p>Created: {{ album.createdAt | date:'medium' }}</p>
       </div>
+      <ion-button expand="block" fill="outline" (click)="navigateToUpload()">Upload More</ion-button>
     </div>
 
     <div *ngIf="album.items.length === 0" class="empty-state">
@@ -88,7 +89,7 @@
     </ion-card>
   </div>
 
-  <ion-fab vertical="bottom" horizontal="end" slot="fixed" *ngIf="album?.version === AlbumVersion.RAW">
+  <ion-fab vertical="bottom" horizontal="end" slot="fixed" *ngIf="album">
     <ion-fab-button (click)="navigateToUpload()">
       <ion-icon name="cloud-upload-outline"></ion-icon>
     </ion-fab-button>

--- a/frontend/mobile/src/app/pages/album-detail/album-detail.page.ts
+++ b/frontend/mobile/src/app/pages/album-detail/album-detail.page.ts
@@ -11,6 +11,7 @@ import { addIcons } from 'ionicons';
 import { shareOutline, cloudUploadOutline, eyeOutline, checkmarkCircleOutline, imagesOutline, trashOutline } from 'ionicons/icons';
 import { AlbumsService } from '../../services/albums.service';
 import { AlbumDetail, AlbumVersion, ItemKind } from '../../models/types';
+import { ViewWillEnter } from '@ionic/angular';
 
 @Component({
   selector: 'app-album-detail',
@@ -24,7 +25,7 @@ import { AlbumDetail, AlbumVersion, ItemKind } from '../../models/types';
     IonFab, IonFabButton, IonGrid, IonRow, IonCol, IonImg, IonBadge
   ]
 })
-export class AlbumDetailPage implements OnInit {
+export class AlbumDetailPage implements OnInit, ViewWillEnter {
   albumId!: number;
   album: AlbumDetail | null = null;
   loading = true;
@@ -45,8 +46,11 @@ export class AlbumDetailPage implements OnInit {
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
       this.albumId = parseInt(id, 10);
-      this.loadAlbum();
     }
+  }
+
+  ionViewWillEnter() {
+    this.loadAlbum();
   }
 
   loadAlbum() {
@@ -115,7 +119,7 @@ export class AlbumDetailPage implements OnInit {
           role: 'destructive',
           handler: () => {
             this.albumsService.deleteAlbum(this.albumId).subscribe({
-              next: () => this.router.navigate(['/projects', this.album!.projectId]),
+              next: () => this.router.navigate(['/project', this.album!.projectId]),
               error: (err) => console.error('Failed to delete album:', err)
             });
           }

--- a/frontend/mobile/src/app/pages/auth/auth.page.ts
+++ b/frontend/mobile/src/app/pages/auth/auth.page.ts
@@ -38,7 +38,7 @@ export class AuthPage {
   ) {
     addIcons({ mailOutline, lockClosedOutline, personOutline });
     if (this.authService.isAuthenticated) {
-      this.router.navigate(['/projects']);
+      this.router.navigate(['/dashboard']);
     }
   }
 
@@ -62,7 +62,7 @@ export class AuthPage {
         await this.authService.register(registerRequest).toPromise();
       }
       
-      this.router.navigate(['/projects']);
+      this.router.navigate(['/dashboard']);
     } catch (error: any) {
       this.error = error.error?.message || 'Authentication failed';
     } finally {

--- a/frontend/mobile/src/app/pages/dashboard/dashboard.page.html
+++ b/frontend/mobile/src/app/pages/dashboard/dashboard.page.html
@@ -1,0 +1,14 @@
+<ion-header [translucent]="true">
+  <ion-toolbar>
+    <ion-title>Dashboard</ion-title>
+    <ion-toggle slot="end" [checked]="darkMode" (ionChange)="toggleTheme($event)"></ion-toggle>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content [fullscreen]="true" class="ion-padding">
+  <ion-list>
+    <ion-item routerLink="/project">
+      <ion-label>My Projects</ion-label>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/frontend/mobile/src/app/pages/dashboard/dashboard.page.scss
+++ b/frontend/mobile/src/app/pages/dashboard/dashboard.page.scss
@@ -1,0 +1,1 @@
+/* Dashboard specific styles */

--- a/frontend/mobile/src/app/pages/dashboard/dashboard.page.ts
+++ b/frontend/mobile/src/app/pages/dashboard/dashboard.page.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import {
+  IonContent, IonHeader, IonTitle, IonToolbar, IonList, IonItem, IonLabel,
+  IonToggle
+} from '@ionic/angular/standalone';
+import { ThemeService } from '../../services/theme.service';
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.page.html',
+  styleUrls: ['./dashboard.page.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink,
+    IonContent, IonHeader, IonTitle, IonToolbar, IonList, IonItem, IonLabel,
+    IonToggle
+  ]
+})
+export class DashboardPage {
+  darkMode = false;
+
+  constructor(private themeService: ThemeService) {
+    this.darkMode = this.themeService.isDarkMode();
+  }
+
+  toggleTheme(ev: CustomEvent) {
+    const isDark = ev.detail.checked;
+    this.themeService.setDarkMode(isDark);
+    this.darkMode = isDark;
+  }
+}

--- a/frontend/mobile/src/app/pages/project-detail/project-detail.page.html
+++ b/frontend/mobile/src/app/pages/project-detail/project-detail.page.html
@@ -1,7 +1,7 @@
 <ion-header [translucent]="true">
   <ion-toolbar>
     <ion-buttons slot="start">
-      <ion-back-button defaultHref="/projects"></ion-back-button>
+      <ion-back-button defaultHref="/project"></ion-back-button>
     </ion-buttons>
     <ion-title>{{ project?.name || 'Project' }}</ion-title>
     <ion-buttons slot="end">

--- a/frontend/mobile/src/app/pages/project-detail/project-detail.page.ts
+++ b/frontend/mobile/src/app/pages/project-detail/project-detail.page.ts
@@ -12,6 +12,7 @@ import { addOutline, imageOutline, videocamOutline, eyeOutline, checkmarkCircleO
 import { ProjectsService } from '../../services/projects.service';
 import { AlbumsService } from '../../services/albums.service';
 import { ProjectDetail, AlbumSummary, CreateAlbumRequest, AlbumVersion, UpdateProjectRequest } from '../../models/types';
+import { ViewWillEnter } from '@ionic/angular';
 
 @Component({
   selector: 'app-project-detail',
@@ -25,7 +26,7 @@ import { ProjectDetail, AlbumSummary, CreateAlbumRequest, AlbumVersion, UpdatePr
     IonCardContent, IonSpinner, IonText, IonBadge
   ]
 })
-export class ProjectDetailPage implements OnInit {
+export class ProjectDetailPage implements OnInit, ViewWillEnter {
   projectId!: number;
   project: ProjectDetail | null = null;
   loading = true;
@@ -45,8 +46,11 @@ export class ProjectDetailPage implements OnInit {
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
       this.projectId = parseInt(id, 10);
-      this.loadProject();
     }
+  }
+
+  ionViewWillEnter() {
+    this.loadProject();
   }
 
   loadProject() {
@@ -170,7 +174,7 @@ export class ProjectDetailPage implements OnInit {
           role: 'destructive',
           handler: () => {
             this.projectsService.deleteProject(this.projectId).subscribe({
-              next: () => this.router.navigate(['/projects']),
+              next: () => this.router.navigate(['/project']),
               error: (err) => console.error('Failed to delete project:', err)
             });
           }

--- a/frontend/mobile/src/app/pages/projects/projects.page.ts
+++ b/frontend/mobile/src/app/pages/projects/projects.page.ts
@@ -11,6 +11,7 @@ import { addOutline, folderOpenOutline, logOutOutline, qrCodeOutline } from 'ion
 import { ProjectsService } from '../../services/projects.service';
 import { AuthService } from '../../services/auth.service';
 import { Project, CreateProjectRequest, DashboardStats } from '../../models/types';
+import { ViewWillEnter } from '@ionic/angular';
 
 @Component({
   selector: 'app-projects',
@@ -24,7 +25,7 @@ import { Project, CreateProjectRequest, DashboardStats } from '../../models/type
     IonButton, IonButtons, IonSpinner, IonText
   ]
 })
-export class ProjectsPage implements OnInit {
+export class ProjectsPage implements OnInit, ViewWillEnter {
   projects: Project[] = [];
   loading = true;
   error = '';
@@ -39,7 +40,9 @@ export class ProjectsPage implements OnInit {
     addIcons({ addOutline, folderOpenOutline, logOutOutline, qrCodeOutline });
   }
 
-  ngOnInit() {
+  ngOnInit() {}
+
+  ionViewWillEnter() {
     this.loadProjects();
     this.loadStats();
   }
@@ -104,7 +107,7 @@ export class ProjectsPage implements OnInit {
     this.projectsService.createProject(request).subscribe({
       next: (project) => {
         this.projects.unshift(project);
-        this.router.navigate(['/projects', project.id]);
+        this.router.navigate(['/project', project.id]);
       },
       error: (error) => {
         console.error('Failed to create project:', error);
@@ -113,7 +116,7 @@ export class ProjectsPage implements OnInit {
   }
 
   openProject(project: Project) {
-    this.router.navigate(['/projects', project.id]);
+    this.router.navigate(['/project', project.id]);
   }
 
   async logout() {

--- a/frontend/mobile/src/app/pages/scanner/scanner.page.html
+++ b/frontend/mobile/src/app/pages/scanner/scanner.page.html
@@ -1,7 +1,7 @@
 <ion-header [translucent]="true">
   <ion-toolbar>
     <ion-buttons slot="start">
-      <ion-back-button defaultHref="/projects"></ion-back-button>
+      <ion-back-button defaultHref="/project"></ion-back-button>
     </ion-buttons>
     <ion-title>QR Scanner</ion-title>
   </ion-toolbar>

--- a/frontend/mobile/src/app/services/theme.service.ts
+++ b/frontend/mobile/src/app/services/theme.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private dark = false;
+
+  isDarkMode(): boolean {
+    return this.dark;
+  }
+
+  setDarkMode(isDark: boolean) {
+    this.dark = isDark;
+    document.body.classList.toggle('dark', isDark);
+  }
+}

--- a/frontend/mobile/src/global.scss
+++ b/frontend/mobile/src/global.scss
@@ -33,13 +33,12 @@
  */
 
 /* @import "@ionic/angular/css/palettes/dark.always.css"; */
-/* @import "@ionic/angular/css/palettes/dark.class.css"; */
-@import "@ionic/angular/css/palettes/dark.system.css";
+@import "@ionic/angular/css/palettes/dark.class.css";
 
 /* App-specific global styles */
 .app-title {
   font-weight: 700;
-  color: var(--ion-color-dark);
+  color: var(--ion-text-color);
 }
 
 .text-center {


### PR DESCRIPTION
## Summary
- Add `/dashboard` home with dark/light mode toggle and link to My Projects
- Support adding more images to albums and auto-refresh pages on reentry
- Rename project routes to `/project` and update navigation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: all files ignored)*

------
https://chatgpt.com/codex/tasks/task_e_68c5718f732c832f883fb30ffe87d31c