### PR TITLE
feat: improve dashboard stats and uploads

### DIFF
--- a/frontend/mobile/src/app/pages/dashboard/dashboard.page.html
+++ b/frontend/mobile/src/app/pages/dashboard/dashboard.page.html
@@ -6,6 +6,29 @@
 </ion-header>
 
 <ion-content [fullscreen]="true" class="ion-padding">
+  <ion-card *ngIf="stats" class="stats-card">
+    <ion-card-content>
+      <div class="stats-grid">
+        <div>
+          <h3>{{ stats.projectCount }}</h3>
+          <p>Projects</p>
+        </div>
+        <div>
+          <h3>{{ stats.albumCount }}</h3>
+          <p>Albums</p>
+        </div>
+        <div>
+          <h3>{{ stats.imageCount }}</h3>
+          <p>Images</p>
+        </div>
+        <div>
+          <h3>{{ stats.totalImageMb | number:'1.1-1' }}</h3>
+          <p>MB Uploaded</p>
+        </div>
+      </div>
+    </ion-card-content>
+  </ion-card>
+
   <ion-list>
     <ion-item routerLink="/project">
       <ion-label>My Projects</ion-label>

--- a/frontend/mobile/src/app/pages/dashboard/dashboard.page.scss
+++ b/frontend/mobile/src/app/pages/dashboard/dashboard.page.scss
@@ -1,1 +1,23 @@
 /* Dashboard specific styles */
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+
+  div {
+    text-align: center;
+
+    h3 {
+      margin: 0;
+      font-size: 1.5rem;
+      color: var(--ion-color-primary);
+    }
+
+    p {
+      margin: 0;
+      color: var(--ion-color-medium);
+      font-size: 0.8rem;
+    }
+  }
+}

--- a/frontend/mobile/src/app/pages/dashboard/dashboard.page.ts
+++ b/frontend/mobile/src/app/pages/dashboard/dashboard.page.ts
@@ -3,9 +3,12 @@ import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import {
   IonContent, IonHeader, IonTitle, IonToolbar, IonList, IonItem, IonLabel,
-  IonToggle
+  IonToggle, IonCard, IonCardContent
 } from '@ionic/angular/standalone';
 import { ThemeService } from '../../services/theme.service';
+import { ProjectsService } from '../../services/projects.service';
+import { DashboardStats } from '../../models/types';
+import { ViewWillEnter } from '@ionic/angular';
 
 @Component({
   selector: 'app-dashboard',
@@ -16,19 +19,34 @@ import { ThemeService } from '../../services/theme.service';
     CommonModule,
     RouterLink,
     IonContent, IonHeader, IonTitle, IonToolbar, IonList, IonItem, IonLabel,
-    IonToggle
+    IonToggle, IonCard, IonCardContent
   ]
 })
-export class DashboardPage {
+export class DashboardPage implements ViewWillEnter {
   darkMode = false;
+  stats: DashboardStats | null = null;
 
-  constructor(private themeService: ThemeService) {
+  constructor(
+    private themeService: ThemeService,
+    private projectsService: ProjectsService
+  ) {
     this.darkMode = this.themeService.isDarkMode();
+  }
+
+  ionViewWillEnter() {
+    this.loadStats();
   }
 
   toggleTheme(ev: CustomEvent) {
     const isDark = ev.detail.checked;
     this.themeService.setDarkMode(isDark);
     this.darkMode = isDark;
+  }
+
+  private loadStats() {
+    this.projectsService.getStats().subscribe({
+      next: (stats) => (this.stats = stats),
+      error: (err) => console.error('Failed to load stats:', err)
+    });
   }
 }

--- a/frontend/mobile/src/app/pages/projects/projects.page.html
+++ b/frontend/mobile/src/app/pages/projects/projects.page.html
@@ -1,5 +1,8 @@
 <ion-header [translucent]="true">
   <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/dashboard"></ion-back-button>
+    </ion-buttons>
     <ion-title>My Projects</ion-title>
     <ion-buttons slot="end">
       <ion-button (click)="navigateToScanner()">
@@ -26,29 +29,6 @@
   </div>
 
   <div *ngIf="!loading && !error">
-    <ion-card *ngIf="stats" class="stats-card">
-      <ion-card-content>
-        <div class="stats-grid">
-          <div>
-            <h3>{{ stats.projectCount }}</h3>
-            <p>Projects</p>
-          </div>
-          <div>
-            <h3>{{ stats.albumCount }}</h3>
-            <p>Albums</p>
-          </div>
-          <div>
-            <h3>{{ stats.imageCount }}</h3>
-            <p>Images</p>
-          </div>
-          <div>
-            <h3>{{ stats.totalImageMb | number:'1.1-1' }}</h3>
-            <p>MB Uploaded</p>
-          </div>
-        </div>
-      </ion-card-content>
-    </ion-card>
-
     <div *ngIf="projects.length === 0" class="empty-state">
       <ion-icon name="folder-open-outline" size="large"></ion-icon>
       <h2>No Projects Yet</h2>

--- a/frontend/mobile/src/app/pages/projects/projects.page.scss
+++ b/frontend/mobile/src/app/pages/projects/projects.page.scss
@@ -88,25 +88,3 @@ ion-card {
 ion-list {
   padding: 0;
 }
-
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1rem;
-
-  div {
-    text-align: center;
-
-    h3 {
-      margin: 0;
-      font-size: 1.5rem;
-      color: var(--ion-color-primary);
-    }
-
-    p {
-      margin: 0;
-      color: var(--ion-color-medium);
-      font-size: 0.8rem;
-    }
-  }
-}

--- a/frontend/mobile/src/app/pages/projects/projects.page.ts
+++ b/frontend/mobile/src/app/pages/projects/projects.page.ts
@@ -1,16 +1,16 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
-import { 
-  IonContent, IonHeader, IonTitle, IonToolbar, IonFab, IonFabButton, 
+import {
+  IonContent, IonHeader, IonTitle, IonToolbar, IonFab, IonFabButton,
   IonIcon, IonList, IonItem, IonLabel, IonCard, IonCardContent,
-  IonButton, IonButtons, IonSpinner, IonText, AlertController
+  IonButton, IonButtons, IonSpinner, IonText, AlertController, IonBackButton
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { addOutline, folderOpenOutline, logOutOutline, qrCodeOutline } from 'ionicons/icons';
 import { ProjectsService } from '../../services/projects.service';
 import { AuthService } from '../../services/auth.service';
-import { Project, CreateProjectRequest, DashboardStats } from '../../models/types';
+import { Project, CreateProjectRequest } from '../../models/types';
 import { ViewWillEnter } from '@ionic/angular';
 
 @Component({
@@ -22,14 +22,13 @@ import { ViewWillEnter } from '@ionic/angular';
     CommonModule,
     IonContent, IonHeader, IonTitle, IonToolbar, IonFab, IonFabButton,
     IonIcon, IonList, IonItem, IonLabel, IonCard, IonCardContent,
-    IonButton, IonButtons, IonSpinner, IonText
+    IonButton, IonButtons, IonSpinner, IonText, IonBackButton
   ]
 })
 export class ProjectsPage implements OnInit, ViewWillEnter {
   projects: Project[] = [];
   loading = true;
   error = '';
-  stats: DashboardStats | null = null;
 
   constructor(
     private projectsService: ProjectsService,
@@ -44,7 +43,6 @@ export class ProjectsPage implements OnInit, ViewWillEnter {
 
   ionViewWillEnter() {
     this.loadProjects();
-    this.loadStats();
   }
 
   loadProjects() {
@@ -61,13 +59,6 @@ export class ProjectsPage implements OnInit, ViewWillEnter {
         this.loading = false;
         console.error(error);
       }
-    });
-  }
-
-  loadStats() {
-    this.projectsService.getStats().subscribe({
-      next: (stats) => (this.stats = stats),
-      error: (err) => console.error('Failed to load stats:', err)
     });
   }
 

--- a/frontend/mobile/src/app/pages/upload/upload.page.html
+++ b/frontend/mobile/src/app/pages/upload/upload.page.html
@@ -35,6 +35,23 @@
       </ion-button>
     </div>
 
+    <ion-item>
+      <ion-toggle [(ngModel)]="watermarkEnabled" slot="end"></ion-toggle>
+      <ion-label>
+        <h3>Watermark</h3>
+        <p>Add text watermark to all images</p>
+      </ion-label>
+    </ion-item>
+
+    <ion-item *ngIf="watermarkEnabled">
+      <ion-input
+        [(ngModel)]="watermarkText"
+        placeholder="Watermark text"
+        maxlength="50"
+      ></ion-input>
+      <ion-label position="stacked">Watermark Text</ion-label>
+    </ion-item>
+
     <ion-list>
       <ion-card *ngFor="let item of items; trackBy: trackByItemId">
         <ion-card-content>
@@ -65,26 +82,6 @@
             >
               Remove
             </ion-button>
-          </div>
-
-          <!-- Watermark settings for images -->
-          <div *ngIf="item.kind === 'IMAGE' && !item.uploaded" class="watermark-settings">
-            <ion-item>
-              <ion-toggle [(ngModel)]="item.watermarkEnabled" slot="end"></ion-toggle>
-              <ion-label>
-                <h3>Watermark</h3>
-                <p>Add text watermark to this image</p>
-              </ion-label>
-            </ion-item>
-
-            <ion-item *ngIf="item.watermarkEnabled">
-              <ion-input
-                [(ngModel)]="item.watermarkText"
-                placeholder="Watermark text"
-                maxlength="50"
-              ></ion-input>
-              <ion-label position="stacked">Watermark Text</ion-label>
-            </ion-item>
           </div>
         </ion-card-content>
       </ion-card>

--- a/frontend/mobile/src/app/pages/upload/upload.page.scss
+++ b/frontend/mobile/src/app/pages/upload/upload.page.scss
@@ -76,18 +76,6 @@
   }
 }
 
-.watermark-settings {
-  margin-top: 1rem;
-  border-top: 1px solid var(--ion-color-light);
-  padding-top: 1rem;
-
-  ion-item {
-    --background: transparent;
-    --padding-start: 0;
-    --inner-padding-end: 0;
-  }
-}
-
 .upload-actions {
   margin-top: 2rem;
   padding-bottom: 2rem;

--- a/frontend/mobile/src/app/pages/upload/upload.page.ts
+++ b/frontend/mobile/src/app/pages/upload/upload.page.ts
@@ -8,7 +8,7 @@ import {
   IonContent, IonHeader, IonTitle, IonToolbar, IonBackButton, IonButtons,
   IonList, IonItem, IonLabel, IonButton, IonIcon, IonToggle, IonInput,
   IonCard, IonCardContent, IonProgressBar, IonText, ActionSheetController,
-  IonLoading
+  IonLoading, ToastController
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { cameraOutline, imagesOutline, videocamOutline, cloudUploadOutline } from 'ionicons/icons';
@@ -19,8 +19,6 @@ interface UploadItem {
   id: string;
   file: File;
   kind: ItemKind;
-  watermarkEnabled: boolean;
-  watermarkText: string;
   uploading: boolean;
   uploaded: boolean;
   progress: number;
@@ -43,6 +41,8 @@ export class UploadPage implements OnInit {
   albumId!: number;
   items: UploadItem[] = [];
   uploading = false;
+  watermarkEnabled = false;
+  watermarkText = '© EarthInfo Systems';
   trackByItemId!: TrackByFunction<UploadItem>;
   @ViewChild('fileInput') fileInput!: ElementRef<HTMLInputElement>;
 
@@ -50,7 +50,8 @@ export class UploadPage implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     private uploadService: UploadService,
-    private actionSheetController: ActionSheetController
+    private actionSheetController: ActionSheetController,
+    private toastController: ToastController
   ) {
     addIcons({ cameraOutline, imagesOutline, videocamOutline, cloudUploadOutline });
   }
@@ -124,8 +125,6 @@ export class UploadPage implements OnInit {
         id: Date.now().toString() + Math.random(),
         file,
         kind: ItemKind.IMAGE,
-        watermarkEnabled: false,
-        watermarkText: '© EarthInfo Systems',
         uploading: false,
         uploaded: false,
         progress: 0
@@ -156,8 +155,6 @@ export class UploadPage implements OnInit {
       id: Date.now().toString(),
       file,
       kind,
-      watermarkEnabled: false,
-      watermarkText: '© EarthInfo Systems',
       uploading: false,
       uploaded: false,
       progress: 0
@@ -197,6 +194,12 @@ export class UploadPage implements OnInit {
 
     // Navigate back if all uploads successful
     if (this.items.every(item => item.uploaded)) {
+      const toast = await this.toastController.create({
+        message: 'Upload complete',
+        duration: 2000,
+        color: 'success'
+      });
+      await toast.present();
       this.router.navigate(['/albums', this.albumId]);
     }
   }
@@ -207,8 +210,8 @@ export class UploadPage implements OnInit {
         this.albumId,
         item.file,
         item.kind,
-        item.watermarkEnabled,
-        item.watermarkText
+        this.watermarkEnabled,
+        this.watermarkText
       ).subscribe({
         next: (event) => {
           if (event.type === HttpEventType.UploadProgress) {


### PR DESCRIPTION
## Summary
- move stats from project list to dashboard
- add album-level watermark and success toast after uploads
- provide back navigation from projects to dashboard

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: files matching glob are ignored)


------
https://chatgpt.com/codex/tasks/task_e_68c58b6e96b0832f9d5f70fd1dc8f213