### PR TITLE
Add Docker deployment for Render with static frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.gitignore
+Dockerfile
+node_modules
+**/node_modules
+frontend/mobile/www
+frontend/mobile/dist
+backend/api/bin
+backend/api/obj
+backend/api/wwwroot
+infrastructure
+*.md

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ dist/
 **/dist/
 build/
 **/build/
+backend/api/wwwroot/*
+!backend/api/wwwroot/.gitkeep
 
 # Mobile build output
 android/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Stage 1 - Build the Angular frontend
+FROM node:20 AS frontend-builder
+WORKDIR /app
+
+# Install dependencies
+COPY frontend/mobile/package*.json frontend/mobile/
+RUN npm ci --prefix frontend/mobile
+
+# Build the Angular project
+COPY frontend/mobile frontend/mobile
+RUN mkdir -p backend/api/wwwroot \
+    && npm run build --prefix frontend/mobile
+
+# Stage 2 - Build and publish the .NET backend
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS backend-builder
+WORKDIR /src
+
+COPY backend ./backend
+COPY --from=frontend-builder /app/backend/api/wwwroot ./backend/api/wwwroot
+RUN dotnet restore backend/api/QRAlbums.API.csproj
+RUN dotnet publish backend/api/QRAlbums.API.csproj -c Release -o /app/publish
+
+# Stage 3 - Runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+
+COPY --from=backend-builder /app/publish ./
+
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "QRAlbums.API.dll"]

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -85,6 +85,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+app.UseStaticFiles();
+
 app.UseCors("AllowMobile");
 app.UseAuthentication();
 app.UseAuthorization();
@@ -96,5 +98,7 @@ app.MapAlbumEndpoints();
 app.MapMediaEndpoints();
 app.MapViewerEndpoints();
 app.MapSelectionEndpoints();
+
+app.MapFallbackToFile("/index.html");
 
 app.Run();

--- a/frontend/mobile/angular.json
+++ b/frontend/mobile/angular.json
@@ -13,7 +13,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist/qr-albums-mobile",
+            "outputPath": "../../backend/api/wwwroot",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": ["zone.js"],
@@ -113,7 +113,10 @@
     }
   },
   "cli": {
-    "schematicCollections": ["@ionic/angular-toolkit"]
+    "schematicCollections": [
+      "@ionic/angular-toolkit"
+    ],
+    "analytics": false
   },
   "schematics": {
     "@ionic/angular-toolkit:component": {

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: qr-albums-app
+    env: docker
+    plan: starter
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    autoDeploy: true
+    envVars:
+      - key: ASPNETCORE_ENVIRONMENT
+        value: Production
+    healthCheckPath: /


### PR DESCRIPTION
## Summary
- serve the Angular frontend from the ASP.NET API via static file middleware and SPA fallback
- adjust the Angular build output to land in the backend wwwroot and keep the folder tracked
- add a multi-stage Dockerfile, dockerignore, and Render service definition for containerized deployment

## Testing
- `CI=true npm run build` *(fails: TypeScript errors in src/app/pages/settings/settings.page.ts)*


------
https://chatgpt.com/codex/tasks/task_e_68daa3c2da20832f85e06c96b4710247